### PR TITLE
feat: add async parse helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,9 @@ Unified `parse` API for any schema that conforms to the
 Valibot, Arktype, and more.
 
 **standard-parse** provides a simple, consistent interface (`parse`,
-`safeParse`) for validating and parsing input using any schema that implements
-the [Standard Schema V1](https://standardschema.dev) interface.
+`safeParse`, `parseAsync`, `safeParseAsync`) for validating and parsing input
+using any schema that implements the
+[Standard Schema V1](https://standardschema.dev) interface.
 
 ## Why?
 
@@ -40,7 +41,8 @@ library that needs to work with user-provided schemas.
 
 - Works with [Zod](https://github.com/colinhacks/zod),
   [Valibot](https://valibot.dev/), [Arktype](https://arktype.io/), and more.
-- Unified API: `parse()`, `safeParse()`, `is()`
+- Unified API: `parse()`, `safeParse()`, `parseAsync()`, `safeParseAsync()`,
+  `is()`
 - Lightweight abstraction layer
 - Compatible with any schema that implements
   [Standard Schema V1](https://standardschema.dev/).
@@ -225,6 +227,42 @@ Validates that an input matches the schema, narrowing its type.
 ```ts
 if (s.is(schema, input)) {
   // input matches schema
+}
+```
+
+#### `parseAsync(schema, input)`
+
+```ts
+parseAsync<TSchema>(
+  schema: TSchema,
+  input: unknown
+): Promise<StandardSchemaV1.InferOutput<TSchema>>
+```
+
+Validates with sync or async schemas and returns the parsed value, or rejects
+with `ValidationError` on failure.
+
+```ts
+const output = await s.parseAsync(schema, input)
+```
+
+#### `safeParseAsync(schema, input)`
+
+```ts
+safeParseAsync<TSchema>(
+  schema: TSchema,
+  input: unknown
+): Promise<StandardSchemaV1.Result<StandardSchemaV1.InferOutput<TSchema>>>
+```
+
+Returns a promise for the same result shape as `safeParse()`.
+
+```ts
+const result = await s.safeParseAsync(schema, input)
+if (result.issues) {
+  // handle errors
+} else {
+  // result.value is typed
 }
 ```
 

--- a/src/standard-schema.test.ts
+++ b/src/standard-schema.test.ts
@@ -105,4 +105,69 @@ describe("async schemas", () => {
       "Invalid type: Input is a Promise"
     )
   })
+
+  it("safeParseAsync returns the parsed value", async () => {
+    const schema = v.objectAsync({
+      name: v.pipeAsync(
+        v.string(),
+        v.checkAsync(() => Promise.resolve(true))
+      )
+    })
+
+    const result = await s.safeParseAsync(schema, { name: "John" })
+    if (result.issues) {
+      throw new Error("Validation failed")
+    }
+
+    expect(result.value).toEqual({ name: "John" })
+  })
+
+  it("safeParseAsync returns issues if the input is invalid", async () => {
+    const schema = v.objectAsync({
+      name: v.pipeAsync(
+        v.string(),
+        v.checkAsync(
+          (input) => Promise.resolve(input.length >= 3),
+          "Name must be at least 3 characters"
+        )
+      )
+    })
+
+    const result = await s.safeParseAsync(schema, { name: "Jo" })
+    expect(result.issues).toBeDefined()
+    if (!result.issues) {
+      throw new Error("Validation succeeded")
+    }
+
+    expect(result.issues[0]?.message).toBe("Name must be at least 3 characters")
+  })
+
+  it("parseAsync returns the parsed value", async () => {
+    const schema = v.objectAsync({
+      name: v.pipeAsync(
+        v.string(),
+        v.checkAsync(() => Promise.resolve(true))
+      )
+    })
+
+    await expect(s.parseAsync(schema, { name: "John" })).resolves.toEqual({
+      name: "John"
+    })
+  })
+
+  it("parseAsync throws a ValidationError if the input is invalid", async () => {
+    const schema = v.objectAsync({
+      name: v.pipeAsync(
+        v.string(),
+        v.checkAsync(
+          (input) => Promise.resolve(input.length >= 3),
+          "Name must be at least 3 characters"
+        )
+      )
+    })
+
+    await expect(s.parseAsync(schema, { name: "Jo" })).rejects.toThrow(
+      ValidationError
+    )
+  })
 })

--- a/src/standard-schema.ts
+++ b/src/standard-schema.ts
@@ -19,6 +19,19 @@ export function safeParse<TSchema extends StandardSchemaV1>(
 }
 
 /**
+ * Parse the input into the schema, awaiting asynchronous validators when needed
+ * @param schema - The schema to parse against
+ * @param input - The input to parse
+ * @returns The parsed output or validation issues
+ */
+export async function safeParseAsync<TSchema extends StandardSchemaV1>(
+  schema: TSchema,
+  input: unknown
+): Promise<StandardSchemaV1.Result<StandardSchemaV1.InferOutput<TSchema>>> {
+  return await schema["~standard"].validate(input)
+}
+
+/**
  * Parse the input into the schema
  * @param schema - The schema to parse against
  * @param input - The input to parse
@@ -29,6 +42,26 @@ export function parse<TSchema extends StandardSchemaV1>(
   input: unknown
 ): StandardSchemaV1.InferOutput<TSchema> {
   const result = safeParse(schema, input)
+
+  // if the `issues` field exists, the validation failed
+  if (result.issues) {
+    throw new ValidationError(result.issues)
+  }
+
+  return result.value
+}
+
+/**
+ * Parse the input into the schema, awaiting asynchronous validators when needed
+ * @param schema - The schema to parse against
+ * @param input - The input to parse
+ * @returns The parsed output
+ */
+export async function parseAsync<TSchema extends StandardSchemaV1>(
+  schema: TSchema,
+  input: unknown
+): Promise<StandardSchemaV1.InferOutput<TSchema>> {
+  const result = await safeParseAsync(schema, input)
 
   // if the `issues` field exists, the validation failed
   if (result.issues) {


### PR DESCRIPTION
## Summary

Adds async counterparts for the existing sync parsing APIs:

- `safeParseAsync(schema, input)` for schemas whose Standard Schema validator returns a promise
- `parseAsync(schema, input)` for async validation with `ValidationError` on failure
- README API docs for both helpers

The existing `safeParse` / `parse` behavior is unchanged and still throws when a schema returns a promise, preserving the current sync API contract.

## Verification

- `pnpm test`
- `pnpm run check`
