### PR TITLE
feat: add validation issue formatter

### DIFF
--- a/src/format-issues.ts
+++ b/src/format-issues.ts
@@ -1,0 +1,31 @@
+import type { StandardSchemaV1 } from "./types"
+
+function formatPath(path: NonNullable<StandardSchemaV1.Issue["path"]>): string {
+  return path
+    .map((segment) => {
+      const key = typeof segment === "object" ? segment.key : segment
+      return String(key)
+    })
+    .join(".")
+}
+
+/**
+ * Format Standard Schema issues into a readable multiline message.
+ *
+ * @param issues - The validation issues to format
+ * @returns A readable issue summary
+ */
+export function formatIssues(
+  issues: readonly StandardSchemaV1.Issue[]
+): string {
+  if (issues.length === 0) {
+    return "Invalid input"
+  }
+
+  return issues
+    .map((issue) => {
+      const path = issue.path?.length ? `${formatPath(issue.path)}: ` : ""
+      return `- ${path}${issue.message}`
+    })
+    .join("\n")
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
 export * from "./standard-schema"
 export * from "./types"
 export * from "./validation-error"
+export * from "./format-issues"

--- a/src/standard-schema.test.ts
+++ b/src/standard-schema.test.ts
@@ -4,6 +4,7 @@ import { describe, expect, it } from "vitest"
 import { z as zodV4 } from "zod"
 import { z as zodV3 } from "zod-v3"
 
+import { formatIssues } from "./format-issues"
 import * as s from "./standard-schema"
 import { ValidationError } from "./validation-error"
 
@@ -104,5 +105,37 @@ describe("async schemas", () => {
     expect(() => s.parse(schema, { name: "John" })).toThrow(
       "Invalid type: Input is a Promise"
     )
+  })
+})
+
+describe("formatIssues()", () => {
+  it("formats issue messages with paths", () => {
+    expect(
+      formatIssues([
+        {
+          message: "Expected string",
+          path: [{ key: "user" }, { key: "name" }]
+        },
+        {
+          message: "Expected number",
+          path: [{ key: "user" }, { key: "age" }]
+        }
+      ])
+    ).toBe("- user.name: Expected string\n- user.age: Expected number")
+  })
+
+  it("formats empty issue arrays", () => {
+    expect(formatIssues([])).toBe("Invalid input")
+  })
+
+  it("keeps ValidationError messages backward compatible", () => {
+    const error = new ValidationError([
+      {
+        message: "Expected string",
+        path: [{ key: "name" }]
+      }
+    ])
+
+    expect(error.message).toBe("Invalid type: Expected string")
   })
 })

--- a/src/test-matchers/vitest.ts
+++ b/src/test-matchers/vitest.ts
@@ -1,5 +1,6 @@
 import { expect } from "vitest"
 
+import { formatIssues } from "../format-issues"
 import { safeParse } from "../standard-schema"
 import type { StandardSchemaV1 } from "../types"
 
@@ -48,18 +49,6 @@ function toMatchSchema<TOutput>(
     pass: true,
     message: () => `Expected ${JSON.stringify(received)} not to match schema`
   }
-}
-
-function formatIssues(issues: readonly StandardSchemaV1.Issue[]): string {
-  return issues
-    .map((issue) => {
-      const pathKeys = issue.path?.map((p) =>
-        typeof p === "object" ? p.key : p
-      )
-      const path = pathKeys ? `${pathKeys.join(".")}:` : ""
-      return `  - ${path} ${issue.message}`
-    })
-    .join("\n")
 }
 
 expect.extend({


### PR DESCRIPTION
## Summary

- add a public `formatIssues()` helper for Standard Schema validation issues
- reuse the helper in the Vitest matcher instead of keeping private formatting logic there
- cover path formatting, empty issue arrays, and current `ValidationError` message compatibility

## Why

Consumers often need to display or log Standard Schema issues without inventing their own issue-path formatter. This keeps the existing `ValidationError` message behavior unchanged while exposing the reusable formatting already needed by the matcher.

## Verification

- `pnpm test -- --run src/standard-schema.test.ts`
- `pnpm run check`
