### PR TITLE
fix: align is() with parse() using Array.isArray issues check

### DIFF
--- a/packages/standard-parse/src/standard-schema.test.ts
+++ b/packages/standard-parse/src/standard-schema.test.ts
@@ -5,6 +5,7 @@ import { z as zodV4 } from "zod"
 import { z as zodV3 } from "zod-v3"
 
 import * as s from "./standard-schema"
+import type { StandardSchemaV1 } from "./types"
 import { ValidationError } from "./validation-error"
 
 const schemaLibraries = {
@@ -78,6 +79,47 @@ describe.each(Object.entries(schemaLibraries))(
     })
   }
 )
+
+describe("result discrimination", () => {
+  it("treats falsy non-array issues as success for parse() and is()", () => {
+    const schema = {
+      "~standard": {
+        version: 1,
+        vendor: "test",
+        validate: () => ({ value: { ok: true }, issues: null })
+      }
+    } as unknown as StandardSchemaV1
+
+    expect(s.parse(schema, {})).toEqual({ ok: true })
+    expect(s.is(schema, {})).toBe(true)
+  })
+
+  it("treats an issues array as failure for parse() and is()", () => {
+    const schema = {
+      "~standard": {
+        version: 1,
+        vendor: "test",
+        validate: () => ({ issues: [{ message: "bad" }] })
+      }
+    } as StandardSchemaV1
+
+    expect(() => s.parse(schema, {})).toThrow(ValidationError)
+    expect(s.is(schema, {})).toBe(false)
+  })
+
+  it("treats an empty issues array as failure for parse() and is()", () => {
+    const schema = {
+      "~standard": {
+        version: 1,
+        vendor: "test",
+        validate: () => ({ issues: [] })
+      }
+    } as StandardSchemaV1
+
+    expect(() => s.parse(schema, {})).toThrow(ValidationError)
+    expect(s.is(schema, {})).toBe(false)
+  })
+})
 
 describe("async schemas", () => {
   it("throws if the result is a promise", () => {

--- a/packages/standard-parse/src/standard-schema.ts
+++ b/packages/standard-parse/src/standard-schema.ts
@@ -1,6 +1,12 @@
 import type { StandardSchemaV1 } from "./types"
 import { ValidationError } from "./validation-error"
 
+function hasValidationIssues(
+  result: StandardSchemaV1.Result<unknown>
+): result is StandardSchemaV1.FailureResult {
+  return Array.isArray(result.issues)
+}
+
 /**
  * Parse the input into the schema
  * @param schema - The schema to parse against
@@ -30,8 +36,7 @@ export function parse<TSchema extends StandardSchemaV1>(
 ): StandardSchemaV1.InferOutput<TSchema> {
   const result = safeParse(schema, input)
 
-  // if the `issues` field exists, the validation failed
-  if (result.issues) {
+  if (hasValidationIssues(result)) {
     throw new ValidationError(result.issues)
   }
 
@@ -49,5 +54,5 @@ export function is<TSchema extends StandardSchemaV1>(
   input: unknown
 ): input is StandardSchemaV1.InferOutput<TSchema> {
   const result = safeParse(schema, input)
-  return result.issues === undefined
+  return !hasValidationIssues(result)
 }


### PR DESCRIPTION
## Summary

- unify success/failure discrimination in `parse()` and `is()` via `Array.isArray(result.issues)`
- fixes inconsistency where `parse()` treated falsy non-array `issues` (e.g. `null`) as success while `is()` returned `false`

## Why

Standard Schema treats validation failure as an `issues` array. Using `issues === undefined` in `is()` diverged from the truthy `issues` check in `parse()` for edge-case results.

## Test plan

- [x] `pnpm --filter standard-parse test` (28 tests)
- [x] `pnpm --filter standard-parse typecheck`