### PR TITLE
fix(standard-parse): validate schema object and ~standard validate method in safeParse

### DIFF
--- a/packages/standard-parse/src/standard-schema.test.ts
+++ b/packages/standard-parse/src/standard-schema.test.ts
@@ -96,3 +96,16 @@ describe("async schemas", () => {
     )
   })
 })
+
+describe("invalid schemas", () => {
+  it("throws TypeError if schema is null or invalid object", () => {
+    // @ts-expect-error testing invalid runtime schema input
+    expect(() => s.safeParse(null, "test")).toThrow(
+      "Invalid schema: Expected a Standard Schema v1 object"
+    )
+    // @ts-expect-error testing invalid runtime schema input
+    expect(() => s.safeParse({}, "test")).toThrow(
+      "Invalid schema: Expected a Standard Schema v1 object"
+    )
+  })
+})

--- a/packages/standard-parse/src/standard-schema.ts
+++ b/packages/standard-parse/src/standard-schema.ts
@@ -11,6 +11,14 @@ export function safeParse<TSchema extends StandardSchemaV1>(
   schema: TSchema,
   input: unknown
 ): StandardSchemaV1.Result<StandardSchemaV1.InferOutput<TSchema>> {
+  if (
+    !schema ||
+    typeof schema !== "object" ||
+    !("~standard" in schema) ||
+    typeof schema["~standard"]?.validate !== "function"
+  ) {
+    throw new TypeError("Invalid schema: Expected a Standard Schema v1 object")
+  }
   const result = schema["~standard"].validate(input)
   if (result instanceof Promise) {
     throw new TypeError("Invalid type: Input is a Promise")


### PR DESCRIPTION
Added runtime validation in safeParse to ensure schema is a valid object containing ~standard with a validate function. Previously, passing null, undefined, or non-conforming objects threw unhandled TypeError: Cannot read properties of null (reading '~standard'). Added unit tests.